### PR TITLE
Allow the project to build with base >= 4.11.0.0

### DIFF
--- a/src/System/Wordexp.chs
+++ b/src/System/Wordexp.chs
@@ -21,7 +21,9 @@ import Foreign.C
 import Foreign.C.Types
 
 import Data.Array (Ix)
+#if !MIN_VERSION_base(4,11,0)
 import Data.Semigroup (Semigroup(..), Monoid(..))
+#endif
 
 #include <wordexp.h>
 


### PR DESCRIPTION
The package does not build anymore with ghc > 8.4.x because the `base` package made a breaking change in 4.11.0.0 in order to merge monoid and semigroup.

> [1 of 2] Compiling System.Wordexp   ( .stack-work/dist/x86_64-linux-tinfo6-nopie/Cabal-2.2.0.1/build/System/Wordexp.hs, .stack-work/dist/x86_64-linux-tinfo6-nopie/Cabal-2.2.0.1/build/System/Wordexp.o )
> 
> /tmp/wordexp/src/System/Wordexp.chs:26:39: error:
>     Module ‘Data.Semigroup’ does not export ‘Monoid(..)’
>    |
> 26 | #include <wordexp.h>
>    |                                       ^^^^^^^^^^
> 

